### PR TITLE
Adding access type custom

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Resources:
       <td>Access policy of the bucket</td>
       <td>Private</td>
       <td>no</td>
-      <td>[Private, PublicRead, CloudFrontRead, CloudFrontAccessLogWrite, ElbAccessLogWrite, ConfigWrite, CloudTrailWrite, FlowLogWrite]</td>
+      <td>[Private, PublicRead, CloudFrontRead, CloudFrontAccessLogWrite, ElbAccessLogWrite, ConfigWrite, CloudTrailWrite, FlowLogWrite, Custom]</td>
     </tr>
     <tr>
       <td>Cors</td>

--- a/module.yml
+++ b/module.yml
@@ -28,7 +28,7 @@ Parameters:
     Description: 'Access policy of the bucket.'
     Type: String
     Default: Private
-    AllowedValues: [Private, PublicRead, CloudFrontRead, CloudFrontAccessLogWrite, ElbAccessLogWrite, ConfigWrite, CloudTrailWrite, FlowLogWrite]
+    AllowedValues: [Private, PublicRead, CloudFrontRead, CloudFrontAccessLogWrite, ElbAccessLogWrite, ConfigWrite, CloudTrailWrite, FlowLogWrite, Custom]
   Cors:
     Description: 'CORS policy of the bucket.'
     Type: String
@@ -388,7 +388,7 @@ Outputs:
   ModuleId:
     Value: 's3-bucket'
   ModuleVersion:
-    Value: '1.5.0'
+    Value: '1.6.0'
   StackName:
     Value: !Ref 'AWS::StackName'
   Arn:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cfn-modules/s3-bucket",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "AWS S3 bucket with encryption and backups",
   "author": "Michael Wittig <michael@widdix.de>",
   "license": "Apache-2.0",


### PR DESCRIPTION
Use access type `Custom` when you need to define your own bucket policy.